### PR TITLE
Fix release tag for Galactic and Rolling

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -171,7 +171,7 @@ tracks:
     patches: null
     release_inc: '2'
     release_repo_url: null
-    release_tag: ros2
+    release_tag: :{version}
     ros_distro: galactic
     vcs_type: git
     vcs_uri: https://github.com/ament/googletest.git
@@ -222,7 +222,7 @@ tracks:
     patches: null
     release_inc: '1'
     release_repo_url: null
-    release_tag: ros2
+    release_tag: :{version}
     ros_distro: rolling
     vcs_type: git
     vcs_uri: https://github.com/ament/googletest.git


### PR DESCRIPTION
I must have made a mistake when originally making a release for Foxy, which got carried forward for Galactic and Rolling.
I've since fixed the error with the lates Foxy release.